### PR TITLE
Add zod_type metadata support for custom Zod expressions

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -326,7 +326,9 @@ func (d *Definition) writeZodBaseObject(fields []Field, objectName string, build
 		case field.Metadata["options"] != nil:
 			writeZodEnum(field, builder)
 		default:
-			if customTypeName, ok := field.Metadata["type"].(string); ok {
+			if zodType, ok := field.Metadata["zod_type"].(string); ok && zodType != "" {
+				builder.WriteString(zodType)
+			} else if customTypeName, ok := field.Metadata["type"].(string); ok {
 				builder.WriteString(getTypeNameForZod(customTypeName))
 			} else {
 				builder.WriteString("z." + field.Type.JSType + "()")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -786,6 +786,31 @@ func Test_writeZodBaseObject(t *testing.T) {
 })`,
 		},
 		{
+			name:       "zod_type override",
+			definition: Definition{},
+			fields: []Field{
+				{
+					NameLowerSnake: "email",
+					Metadata: map[string]interface{}{
+						"zod_type": "z.string().email()",
+					},
+					Type: FieldType{JSType: "string"},
+				},
+				{
+					NameLowerSnake: "count",
+					Metadata: map[string]interface{}{
+						"zod_type": "z.number().int().positive()",
+					},
+					Type: FieldType{JSType: "number"},
+				},
+			},
+			objectName: "GreetRequest",
+			want: `z.object({
+	email: z.string().email(),
+	count: z.number().int().positive(),
+})`,
+		},
+		{
 			name:       "Modifiers",
 			definition: Definition{},
 			fields: []Field{


### PR DESCRIPTION
## Summary

- Adds support for a `zod_type` metadata key on fields, allowing a raw Zod expression to be written directly into the generated schema
- `zod_type` takes precedence over the existing `type` and JS type fallbacks in `writeZodBaseObject`
- Adds a test case (`zod_type override`) to `Test_writeZodBaseObject` covering the new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)